### PR TITLE
Changed BMP buffer of shorts to chars and increased MCU buffer size

### DIFF
--- a/include/bmp.h
+++ b/include/bmp.h
@@ -34,9 +34,9 @@ typedef struct BmpObject {
 } BmpObject;
 
 int write_bmp_cpu(const char *filename, uint32_t image_width, uint32_t image_height, uint32_t image_padding,
-                  uint32_t mcu_width, short *MCU_buffer);
+                  uint32_t mcu_width, char *MCU_buffer);
 
 int write_bmp_dpu(const char *filename, uint32_t image_width, uint32_t image_height, uint32_t image_padding,
-                  uint32_t mcu_width, short *MCU_buffer);
+                  uint32_t mcu_width, char *MCU_buffer);
 
 #endif // _BMP__H

--- a/include/jpeg-host.h
+++ b/include/jpeg-host.h
@@ -78,7 +78,7 @@ typedef struct host_dpu_descriptor {
   uint32_t perf; // value from the DPU's performance counter
   char *in_buffer;  // concatenated buffer for this DPU
   uint32_t in_length; // total length of in_buffer (in bytes)
-  short *out_buffer; // decompressed image data
+  char *out_buffer; // decompressed image data
   uint32_t file_count;	// how many files are assigned to this DPU
   dpu_output_t img[MAX_FILES_PER_DPU];  // decompressed image metadata
   char *filename[MAX_FILES_PER_DPU];

--- a/src/bmp.c
+++ b/src/bmp.c
@@ -40,7 +40,7 @@ static void initialize_bmp_header(BmpObject *image) {
   image->header.size = image->header.data + image->win_header.length;
 }
 
-static void initialize_bmp_body(BmpObject *image, uint32_t image_padding, uint32_t mcu_width, short *MCU_buffer) { //CHANGING BUFF TO SHORT CAUSES ERRORS
+static void initialize_bmp_body(BmpObject *image, uint32_t image_padding, uint32_t mcu_width, char *MCU_buffer) {
   uint8_t *ptr = (uint8_t *) malloc(image->win_header.height * (image->win_header.width * 3 + image_padding));
   image->data = ptr;
 
@@ -53,9 +53,9 @@ static void initialize_bmp_body(BmpObject *image, uint32_t image_padding, uint32
       uint32_t pixel_column = x % 8;
       uint32_t mcu_index = mcu_row * mcu_width + mcu_column;
       uint32_t pixel_index = pixel_row * 8 + pixel_column;
-      ptr[0] = MCU_buffer[(mcu_index * 3 + 2) * 64 + pixel_index];
-      ptr[1] = MCU_buffer[(mcu_index * 3 + 1) * 64 + pixel_index];
-      ptr[2] = MCU_buffer[(mcu_index * 3 + 0) * 64 + pixel_index];
+      ptr[0] = MCU_buffer[((mcu_index * 3 + 2) * 64 + pixel_index)*2];
+      ptr[1] = MCU_buffer[((mcu_index * 3 + 1) * 64 + pixel_index)*2];
+      ptr[2] = MCU_buffer[((mcu_index * 3 + 0) * 64 + pixel_index)*2];
       ptr += 3;
     }
 
@@ -89,7 +89,7 @@ static int write_bmp(const char *filename, uint32_t image_width, uint32_t image_
 
   initialize_window_info_header(&image, image_width, image_height);
   initialize_bmp_header(&image);
-  initialize_bmp_body(&image, image_padding, mcu_width, (short *)MCU_buffer);
+  initialize_bmp_body(&image, image_padding, mcu_width, MCU_buffer);
 
   char *filename_dpu = form_bmp_filename(filename, is_dpu);
   printf("Filename: %s\n", filename_dpu);

--- a/src/bmp.c
+++ b/src/bmp.c
@@ -40,7 +40,7 @@ static void initialize_bmp_header(BmpObject *image) {
   image->header.size = image->header.data + image->win_header.length;
 }
 
-static void initialize_bmp_body(BmpObject *image, uint32_t image_padding, uint32_t mcu_width, short *MCU_buffer) {
+static void initialize_bmp_body(BmpObject *image, uint32_t image_padding, uint32_t mcu_width, short *MCU_buffer) { //CHANGING BUFF TO SHORT CAUSES ERRORS
   uint8_t *ptr = (uint8_t *) malloc(image->win_header.height * (image->win_header.width * 3 + image_padding));
   image->data = ptr;
 
@@ -84,12 +84,12 @@ static int write_bmp_to_file(const char *filename, BmpObject *picture) {
 }
 
 static int write_bmp(const char *filename, uint32_t image_width, uint32_t image_height, uint32_t image_padding,
-                     uint32_t mcu_width, short *MCU_buffer, int is_dpu) {
+                     uint32_t mcu_width, char *MCU_buffer, int is_dpu) {
   BmpObject image;
 
   initialize_window_info_header(&image, image_width, image_height);
   initialize_bmp_header(&image);
-  initialize_bmp_body(&image, image_padding, mcu_width, MCU_buffer);
+  initialize_bmp_body(&image, image_padding, mcu_width, (short *)MCU_buffer);
 
   char *filename_dpu = form_bmp_filename(filename, is_dpu);
   printf("Filename: %s\n", filename_dpu);
@@ -102,12 +102,12 @@ static int write_bmp(const char *filename, uint32_t image_width, uint32_t image_
 }
 
 int write_bmp_cpu(const char *filename, uint32_t image_width, uint32_t image_height, uint32_t image_padding,
-                  uint32_t mcu_width, short *MCU_buffer) {
+                  uint32_t mcu_width, char *MCU_buffer) {
   return write_bmp(filename, image_width, image_height, image_padding, mcu_width, MCU_buffer, 0);
 }
 
 int write_bmp_dpu(const char *filename, uint32_t image_width, uint32_t image_height, uint32_t image_padding,
-                  uint32_t mcu_width, short *MCU_buffer) {
+                  uint32_t mcu_width, char *MCU_buffer) {
   return write_bmp(filename, image_width, image_height, image_padding, mcu_width, MCU_buffer, 1);
 }
 

--- a/src/dpu/dpu-jpeg-decode.c
+++ b/src/dpu/dpu-jpeg-decode.c
@@ -5,7 +5,7 @@
 #include "jpeg-host.h"
 #include "dpu-jpeg.h"
 
-__mram_noinit short MCU_buffer[NR_TASKLETS][MEGABYTE(23) / NR_TASKLETS];
+__mram_noinit char MCU_buffer[NR_TASKLETS][MEGABYTE(47) / NR_TASKLETS];
 
 #define PREWRITE_SIZE 768
 __dma_aligned short MCU_buffer_cache[NR_TASKLETS][PREWRITE_SIZE];
@@ -53,7 +53,7 @@ void decode_bitstream(JpegDecompressor *d) {
             }
 
             int mcu_index = (((row + y) * jpegInfo.mcu_width_real + (col + x)) * 3 + color_index) << 6;
-            mram_write(MCU_buffer_cache[d->tasklet_id], &MCU_buffer[d->tasklet_id][mcu_index], MCU_READ_WRITE_SIZE0);
+            mram_write(MCU_buffer_cache[d->tasklet_id], &MCU_buffer[d->tasklet_id][mcu_index*2], MCU_READ_WRITE_SIZE0);
           }
         }
       }
@@ -107,7 +107,7 @@ static void synchronise_tasklets(JpegDecompressor *d, int row, int col, short *p
                 MCU_buffer_cache[d->tasklet_id + 1][INDEX_OFFSET + next_tasklet_mcu_blocks_elapsed];
 
             int mcu_index = (((row + y) * jpegInfo.mcu_width_real + (col + x)) * 3 + color_index) << 6;
-            mram_write(MCU_buffer_cache[d->tasklet_id], &MCU_buffer[d->tasklet_id][mcu_index], MCU_READ_WRITE_SIZE0);
+            mram_write(MCU_buffer_cache[d->tasklet_id], &MCU_buffer[d->tasklet_id][mcu_index*2], MCU_READ_WRITE_SIZE0);
 
             if (current_tasklet_file_index < next_tasklet_file_index) {
               // Tasklet i needs to decode more blocks
@@ -177,12 +177,12 @@ static void concat_adjust_mcus(JpegDecompressor *d, int row, int col) {
         for (int y = 0; y < jpegInfo.color_components[color_index].v_samp_factor; y++) {
           for (int x = 0; x < jpegInfo.color_components[color_index].h_samp_factor; x++) {
             int mcu_index = (((tasklet_row + y) * jpegInfo.mcu_width_real + (tasklet_col + x)) * 3 + color_index) << 6;
-            mram_read(&MCU_buffer[tasklet_index][mcu_index], MCU_buffer_cache[0], MCU_READ_WRITE_SIZE0);
+            mram_read(&MCU_buffer[tasklet_index][mcu_index*2], MCU_buffer_cache[0], MCU_READ_WRITE_SIZE0);
 
             MCU_buffer_cache[0][0] += dc_offset[color_index];
 
             mcu_index = (((row + y) * jpegInfo.mcu_width_real + (col + x)) * 3 + color_index) << 6;
-            mram_write(MCU_buffer_cache[0], &MCU_buffer[0][mcu_index], MCU_READ_WRITE_SIZE0);
+            mram_write(MCU_buffer_cache[0], &MCU_buffer[0][mcu_index*2], MCU_READ_WRITE_SIZE0);
           }
         }
       }
@@ -346,7 +346,7 @@ void inverse_dct_convert(JpegDecompressor *d) {
           for (int x = 0; x < jpegInfo.color_components[color_index].h_samp_factor; x++) {
             int mcu_index = (((row + y) * jpegInfo.mcu_width_real + (col + x)) * 3 + color_index) << 6;
             int cache_index = ((y << 8) + (y << 7)) + ((x << 7) + (x << 6)) + (color_index << 6);
-            mram_read(&MCU_buffer[0][mcu_index], &MCU_buffer_cache[d->tasklet_id][cache_index], MCU_READ_WRITE_SIZE0);
+            mram_read(&MCU_buffer[0][mcu_index*2], &MCU_buffer_cache[d->tasklet_id][cache_index], MCU_READ_WRITE_SIZE0);
 
             // Compute inverse DCT with ANN algorithm
             inverse_dct_component(d, cache_index);
@@ -364,7 +364,7 @@ void inverse_dct_convert(JpegDecompressor *d) {
 
           ycbcr_to_rgb_pixel(d, cache_index, y, x);
 
-          mram_write(&MCU_buffer_cache[d->tasklet_id][cache_index], &MCU_buffer[0][mcu_index], MCU_READ_WRITE_SIZE1);
+          mram_write(&MCU_buffer_cache[d->tasklet_id][cache_index], &MCU_buffer[0][mcu_index*2], MCU_READ_WRITE_SIZE1);
         }
       }
     }
@@ -572,8 +572,8 @@ void crop(JpegDecompressor *d, int start_x, int start_y, int new_width, int new_
     for (int col = 0; col < new_mcu_width; col++) {
       int mcu_index = (((row + start_row) * jpegInfo.mcu_width_real + (col + start_col)) * 3) << 6;
       int new_mcu_index = ((row * new_mcu_width + col) * 3) << 6;
-      mram_read(&MCU_buffer[0][mcu_index], &MCU_buffer_cache[d->tasklet_id][0], MCU_READ_WRITE_SIZE1);
-      mram_write(&MCU_buffer_cache[d->tasklet_id][0], &MCU_buffer[0][new_mcu_index], MCU_READ_WRITE_SIZE1);
+      mram_read(&MCU_buffer[0][mcu_index*2], &MCU_buffer_cache[d->tasklet_id][0], MCU_READ_WRITE_SIZE1);
+      mram_write(&MCU_buffer_cache[d->tasklet_id][0], &MCU_buffer[0][new_mcu_index*2], MCU_READ_WRITE_SIZE1);
     }
   }
 
@@ -600,7 +600,7 @@ void jpeg_scale(JpegDecompressor *d, int x_scale_factor, int y_scale_factor) {
     for (int col = 0; col < jpegInfo.mcu_width_real; col++) {
       for (int color_index = 0; color_index < jpegInfo.num_color_components; color_index++) {
         int mcu_index = ((row * jpegInfo.mcu_width_real + col) * 3 + color_index) << 6;
-        mram_read(&MCU_buffer[0][mcu_index], &MCU_buffer_cache[d->tasklet_id][0], MCU_READ_WRITE_SIZE0);
+        mram_read(&MCU_buffer[0][mcu_index*2], &MCU_buffer_cache[d->tasklet_id][0], MCU_READ_WRITE_SIZE0);
         for (int y = 0; y < temp0; y++) {
           for (int x = 0; x < temp1; x++) {
             int sum = 0;
@@ -612,7 +612,7 @@ void jpeg_scale(JpegDecompressor *d, int x_scale_factor, int y_scale_factor) {
             MCU_buffer_cache[d->tasklet_id][(y << 3) + x] = sum >> (x_shift + y_shift);
           }
         }
-        mram_write(&MCU_buffer_cache[d->tasklet_id][0], &MCU_buffer[0][mcu_index], MCU_READ_WRITE_SIZE0);
+        mram_write(&MCU_buffer_cache[d->tasklet_id][0], &MCU_buffer[0][mcu_index*2], MCU_READ_WRITE_SIZE0);
       }
     }
   }
@@ -630,7 +630,7 @@ void jpeg_scale(JpegDecompressor *d, int x_scale_factor, int y_scale_factor) {
         for (int i = 0; i < y_scale_factor; i++) {
           for (int j = 0; j < x_scale_factor; j++) {
             int exact_portion_index = general_portion_index + (((i * jpegInfo.mcu_width_real + j) * 3) << 6);
-            mram_read(&MCU_buffer[0][exact_portion_index], &MCU_buffer_cache[d->tasklet_id][64], MCU_READ_WRITE_SIZE0);
+            mram_read(&MCU_buffer[0][exact_portion_index*2], &MCU_buffer_cache[d->tasklet_id][64], MCU_READ_WRITE_SIZE0);
 
             for (int y = 0; y < temp0; y++) {
               for (int x = 0; x < temp1; x++) {
@@ -641,7 +641,7 @@ void jpeg_scale(JpegDecompressor *d, int x_scale_factor, int y_scale_factor) {
           }
         }
 
-        mram_write(&MCU_buffer_cache[d->tasklet_id][0], &MCU_buffer[0][mcu_index], MCU_READ_WRITE_SIZE0);
+        mram_write(&MCU_buffer_cache[d->tasklet_id][0], &MCU_buffer[0][mcu_index*2], MCU_READ_WRITE_SIZE0);
       }
     }
   }
@@ -663,8 +663,8 @@ void horizontal_flip(JpegDecompressor *d) {
     for (int col = 0; col < jpegInfo.mcu_width_real / 2; col++) {
       int mcu_index = ((row * jpegInfo.mcu_width_real + col) * 3) << 6;
       int target_mcu_index = mcu_index + (((jpegInfo.mcu_width_real - (col << 1) - 1) * 3) << 6);
-      mram_read(&MCU_buffer[0][mcu_index], &MCU_buffer_cache[d->tasklet_id][0], MCU_READ_WRITE_SIZE1);
-      mram_read(&MCU_buffer[0][target_mcu_index], &MCU_buffer_cache[d->tasklet_id][192], MCU_READ_WRITE_SIZE1);
+      mram_read(&MCU_buffer[0][mcu_index*2], &MCU_buffer_cache[d->tasklet_id][0], MCU_READ_WRITE_SIZE1);
+      mram_read(&MCU_buffer[0][target_mcu_index*2], &MCU_buffer_cache[d->tasklet_id][192], MCU_READ_WRITE_SIZE1);
 
       for (int color_index = 0; color_index < jpegInfo.num_color_components; color_index++) {
         for (int y = 0; y < 8; y++) {
@@ -678,8 +678,8 @@ void horizontal_flip(JpegDecompressor *d) {
         }
       }
 
-      mram_write(&MCU_buffer_cache[d->tasklet_id][0], &MCU_buffer[0][mcu_index], MCU_READ_WRITE_SIZE1);
-      mram_write(&MCU_buffer_cache[d->tasklet_id][192], &MCU_buffer[0][target_mcu_index], MCU_READ_WRITE_SIZE1);
+      mram_write(&MCU_buffer_cache[d->tasklet_id][0], &MCU_buffer[0][mcu_index*2], MCU_READ_WRITE_SIZE1);
+      mram_write(&MCU_buffer_cache[d->tasklet_id][192], &MCU_buffer[0][target_mcu_index*2], MCU_READ_WRITE_SIZE1);
     }
   }
 }
@@ -698,7 +698,7 @@ void find_sum_rgb(JpegDecompressor *d) {
   for (; row < end_row; row++) {
     for (int col = 0; col < jpegInfo.mcu_width_real; col++) {
       int mcu_index = ((row * jpegInfo.mcu_width_real + col) * 3) << 6;
-      mram_read(&MCU_buffer[0][mcu_index], &MCU_buffer_cache[d->tasklet_id][0], MCU_READ_WRITE_SIZE1);
+      mram_read(&MCU_buffer[0][mcu_index*2], &MCU_buffer_cache[d->tasklet_id][0], MCU_READ_WRITE_SIZE1);
       for (int color_index = 0; color_index < jpegInfo.num_color_components; color_index++) {
         for (int i = 0; i < 64; i++) {
           sum_rgb[color_index] += MCU_buffer_cache[d->tasklet_id][(color_index << 6) + i];

--- a/src/dpu/dpu-jpeg-decode.c
+++ b/src/dpu/dpu-jpeg-decode.c
@@ -5,7 +5,7 @@
 #include "jpeg-host.h"
 #include "dpu-jpeg.h"
 
-__mram_noinit short MCU_buffer[NR_TASKLETS][MEGABYTE(16) / NR_TASKLETS];
+__mram_noinit short MCU_buffer[NR_TASKLETS][MEGABYTE(23) / NR_TASKLETS];
 
 #define PREWRITE_SIZE 768
 __dma_aligned short MCU_buffer_cache[NR_TASKLETS][PREWRITE_SIZE];

--- a/src/jpeg-cpu.c
+++ b/src/jpeg-cpu.c
@@ -898,7 +898,7 @@ static void ycbcr_to_rgb_pixel(short *buffer, short *cbcr, int v, int h) {
   }
 }
 
-static short *decompress_scanline(JpegDecompressor *d) {
+static char *decompress_scanline(JpegDecompressor *d) {
   short *mcus = (short *) malloc((jpegInfo.mcu_height_real * jpegInfo.mcu_width_real) * (3 * 64) * sizeof(short));
   short previous_dcs[3] = {0};
   uint32_t restart_interval = jpegInfo.restart_interval * jpegInfo.max_h_samp_factor * jpegInfo.max_v_samp_factor;
@@ -954,7 +954,7 @@ static short *decompress_scanline(JpegDecompressor *d) {
     }
   }
 
-  return mcus;
+  return (char *)mcus;
 }
 
 /**
@@ -1173,7 +1173,7 @@ void jpeg_cpu_scale(uint64_t file_length, char *filename, char *buffer) {
 #endif
 
   // Process Huffman coded bitstream, perform inverse DCT, and convert YCbCr to RGB
-  short *mcus = decompress_scanline(&decompressor);
+  char *mcus = decompress_scanline(&decompressor);
   if (mcus == NULL || !jpegInfo.valid) {
     fprintf(stderr, "Error: Invalid JPEG\n");
     return;

--- a/src/jpeg-host.c
+++ b/src/jpeg-host.c
@@ -122,7 +122,7 @@ int read_results_dpu_rank(struct dpu_set_t dpu_rank, struct host_rank_context *r
 			continue;
 		}
 
-		rank_ctx->dpus[dpu_id].out_buffer = (short*)malloc(MAX_DECODED_DATA_SIZE);
+		rank_ctx->dpus[dpu_id].out_buffer = (char*)malloc(MAX_DECODED_DATA_SIZE);
 		DPU_ASSERT(dpu_prepare_xfer(dpu, (void *) rank_ctx->dpus[dpu_id].out_buffer));
 
 		if (buf_size > largest_size)


### PR DESCRIPTION
Changed the buffer array in bmp.c from a short type to a char type. Also increased the MCU buffer size in dpu-jpeg-decode.c to reduce artifacting in outputted .bmp files.