### PR TITLE
fix make error when STATS isn't specified and add logs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ jpeg-dpu-*
 DSCF5148.jpg
 
 *.csv
+*.log

--- a/src/dpu/dpu-jpeg-decode.c
+++ b/src/dpu/dpu-jpeg-decode.c
@@ -192,7 +192,9 @@ static void concat_adjust_mcus(JpegDecompressor *d, int row, int col) {
     }
     col = 0;
   }
+#ifdef STATISTICS
 	output.cycles_dc_adj = perfcounter_get() - start_dc_adj;
+#endif // STATISTICS
 }
 
 static int decode_mcu(JpegDecompressor *d, int component_index, short *previous_dc) {


### PR DESCRIPTION
I added an ifdef to prevent the following make error.
```
dpu-jpeg-decode.c:195:9: error: no member named 'cycles_dc_adj' in 'struct dpu_output_t'
        output.cycles_dc_adj = perfcounter_get() - start_dc_adj;
```